### PR TITLE
FizzBuzz Fizzy Buzziness

### DIFF
--- a/objc-fizzbuzz/FISAppDelegate.m
+++ b/objc-fizzbuzz/FISAppDelegate.m
@@ -13,6 +13,50 @@
      
      */
     
+    /*
+    NSUInteger start = 1;
+    NSUInteger limit = 100;
+    
+    for (NSUInteger i = start; i <= limit; i++) {
+        NSString *result = @"";
+        if (i%3 == 0 && i%5 == 0) {
+            result =@"Fizz Buzz";
+        }
+        else if (i%3 == 0) {
+            result = @"Fizz";
+        }
+        else if (i%5 == 0) {
+            result = @"Buzz";
+        }
+        else {
+            result = [NSString stringWithFormat:@"%lu", i];
+        }
+        NSLog(@"%@", result);
+    }
+    */
+    NSUInteger start = 1;
+    NSUInteger limit = 100;
+    NSUInteger fizzIncrement = 3;
+    NSUInteger buzzIncrement = 5;
+    
+    for (NSUInteger i = start; i < limit+1; i++) {
+        NSString *result = @"";
+        if (i % buzzIncrement == 0){
+            if (i%fizzIncrement==0) {
+                result = @"FizzBuzz";
+            }
+            else {
+                result = @"Buzz";
+            }
+        }
+        else if (i%fizzIncrement==0) {
+            result=@"Fizz";
+        }
+        else {
+            result = [NSString stringWithFormat:@"%lu", i];
+        }
+        NSLog(@"%@", result);
+    }
     // do not alter
     return YES;  //
     ///////////////


### PR DESCRIPTION
I thought I can reduce one operation from the instructions by setting the loop stop to <limit+1. This way (if 100 was the limit) it doesn't have to check 100 twice. First for being less than, and second for being equal to, then having to check 101 to cause a stop.

As far as the body if, else if, and else statements. The buzzIncrement (5) would occur less often than the fizzIncrement, so I nested the test for both inside that statement to reduce the number of conditional checks for both. I don't know how much this would improve efficiency, but hopefully it's a start. 
